### PR TITLE
Add netfilter communication host

### DIFF
--- a/traffy-netfilter-communication-host/api/host.py
+++ b/traffy-netfilter-communication-host/api/host.py
@@ -1,0 +1,27 @@
+"""
+ Copyright (C) 2020 Falk Seidl <hi@falsei.de>
+ 
+ Author: Falk Seidl <hi@falsei.de>
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License as
+ published by the Free Software Foundation; either version 2 of the
+ License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+class HostAPI():
+    host_version = "0.1"
+    api_version = "1.0"
+    host = NotImplemented
+
+    def __init__(self, host):
+        self.host = host

--- a/traffy-netfilter-communication-host/host.py
+++ b/traffy-netfilter-communication-host/host.py
@@ -1,0 +1,63 @@
+"""
+ Copyright (C) 2020 Falk Seidl <hi@falsei.de>
+ 
+ Author: Falk Seidl <hi@falsei.de>
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License as
+ published by the Free Software Foundation; either version 2 of the
+ License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, see <http://www.gnu.org/licenses/>.
+"""
+
+from socket_manager import SocketManager
+from datetime import datetime
+import logging
+import signal
+import os
+
+
+class Host():
+    boot_timestamp = NotImplemented
+    sm = NotImplemented
+
+    def __init__(self):
+        self.setup_logging()
+
+        if os.geteuid() != 0:
+            logging.error("Need to run as root! Exiting…")
+            return
+
+        self.boot_timestamp = datetime.now()
+
+        self.sm = SocketManager(self)
+
+        signal.signal(signal.SIGINT, self.shutdown)
+        signal.signal(signal.SIGTERM, self.shutdown)
+        self.startup()
+        signal.pause()
+    
+    def setup_logging(self):
+        logging.basicConfig(format="[%(asctime)s] [%(process)d] [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S %z", level=logging.INFO)
+    
+    def shutdown(self, signal, frame):
+        # Disable Socket
+        self.sm.stop()
+
+        logging.info("Traffy netfilter communication host powered off")
+
+    def startup(self):
+        # Enable Socket
+        self.sm.start()
+
+        logging.info("Traffy netfilter communication host ready to listen")
+        logging.info("Traffy netfilter communication host ready after " + str((datetime.now() - self.boot_timestamp).total_seconds()) + "s")
+
+host = Host()

--- a/traffy-netfilter-communication-host/socket_manager.py
+++ b/traffy-netfilter-communication-host/socket_manager.py
@@ -1,0 +1,50 @@
+"""
+ Copyright (C) 2020 Falk Seidl <hi@falsei.de>
+ 
+ Author: Falk Seidl <hi@falsei.de>
+ 
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU General Public License as
+ published by the Free Software Foundation; either version 2 of the
+ License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, see <http://www.gnu.org/licenses/>.
+"""
+
+from api.host import HostAPI
+from xmlrpc.server import SimpleXMLRPCServer
+import threading
+
+
+class SocketManager():
+    run = True
+    host = NotImplemented
+    rpc = NotImplemented
+    host_api = NotImplemented
+
+    def __init__(self, host):
+        self.host = host
+
+    def start(self):
+        thread = threading.Thread(target=self.__server_start, args=[])
+        thread.daemon = True
+        thread.start()
+
+    def stop(self):
+        self.run = False
+        self.rpc.shutdown()
+        self.rpc.server_close()
+
+    def __server_start(self):
+        while self.run:
+            self.host_api = HostAPI(self.host)
+            self.rpc = SimpleXMLRPCServer(addr=("127.0.0.1", 40405), allow_none=True)
+            self.rpc.register_instance(self.host_api)
+            self.rpc.serve_forever()
+


### PR DESCRIPTION
Reduce the spawning of iptables binaries via command line and the parsing of its output by introducing a netfilter communication host which itself communicates with iptables directly via its C libraries.

![schema](https://user-images.githubusercontent.com/5732964/83802341-dbc51980-a6aa-11ea-8320-af63a0666cd0.png)

